### PR TITLE
New reverse-related checks

### DIFF
--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -1748,6 +1748,18 @@ class LinterPlugin(val global: Global) extends Plugin {
 
             warn(tree, UseInitNotReverseTailReverse(identOrCol(col)))
 
+          case Select(Apply(Select(Select(col, Name("reverse")), Name("take")), _), Name("reverse"))
+            if col.tpe.widen.baseClasses.exists(c => c.tpe =:= TraversableClass.tpe) =>
+
+            warn(tree, UseTakeRightNotReverseTakeReverse(identOrCol(col)))
+
+          case Select(Apply(xArrayOps0, List(Apply(Select(Apply(xArrayOps1, List(Select(Apply(xArrayOps2, List(col)), Name("reverse")))), Name("take")), _))), Name("reverse"))
+            if (xArrayOps0.toString.contains("ArrayOps"))
+            && (xArrayOps1.toString.contains("ArrayOps"))
+            && (xArrayOps2.toString.contains("ArrayOps")) =>
+
+            warn(tree, UseTakeRightNotReverseTakeReverse(identOrCol(col)))
+
           case Select(Select(col, Name("reverse")), head)
             if col.tpe.widen.baseClasses.exists(c => c.tpe =:= TraversableClass.tpe)
             && (head.isAny("head", "headOption")) =>

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -1761,6 +1761,19 @@ class LinterPlugin(val global: Global) extends Plugin {
 
             warn(tree, UseLastNotReverseHead(identOrCol(col), head is "headOption"))
 
+          case Select(Select(col, Name("reverse")), func)
+            if col.tpe.widen.baseClasses.exists(c => c.tpe =:= TraversableClass.tpe)
+            && (func.isAny("map", "iterator")) =>
+
+            warn(tree, UseFuncNotReverse(identOrCol(col), func.toString))
+
+          case Select(Apply(xArrayOps1, List(Select(Apply(xArrayOps2, List(col)), Name("reverse")))), func)
+            if (xArrayOps1.toString.contains("ArrayOps"))
+            && (xArrayOps2.toString.contains("ArrayOps"))
+            && (func.isAny("map", "iterator")) =>
+
+            warn(tree, UseFuncNotReverse(identOrCol(col), func.toString))
+
           /// Use partial function directly - temporary variable is unnecessary (idea by yzgw)
           case Apply(_, List(Function(List(ValDef(mods, x_1, typeTree: TypeTree, EmptyTree)), Match(x_1_, _))))
             if (((x_1 is "x$1") && (x_1_ is "x$1") && (mods.isSynthetic) && (mods.isParameter)) // _ match { ... }

--- a/src/main/scala/Warning.scala
+++ b/src/main/scala/Warning.scala
@@ -107,6 +107,7 @@ object Warning {
     UseQuantifierFuncNotFold("", "", ""),
     UseFuncNotReduce("", "", ""),
     UseFuncNotFold("", "", ""),
+    UseFuncNotReverse("", ""),
     UseInitNotReverseTailReverse(""),
     UseLastNotReverseHead("", true),
     UseIsNanNotNanComparison,
@@ -345,3 +346,5 @@ case class UseInitNotReverseTailReverse(varName: String) extends
   Warning(s"$varName.reverse.tail.reverse can be replaced by $varName.init.")
 case class UseLastNotReverseHead(varName: String, option: Boolean) extends
   Warning(s"""$varName.reverse.head${if (option) "Option" else ""} can be replaced by $varName.last${if (option) "Option" else ""}.""")
+case class UseFuncNotReverse(varName: String, func: String) extends
+  Warning(s"""$varName.reverse.$func can be replaced by $varName.reverse${func.capitalize}.""")

--- a/src/main/scala/Warning.scala
+++ b/src/main/scala/Warning.scala
@@ -109,6 +109,7 @@ object Warning {
     UseFuncNotFold("", "", ""),
     UseFuncNotReverse("", ""),
     UseInitNotReverseTailReverse(""),
+    UseTakeRightNotReverseTakeReverse(""),
     UseLastNotReverseHead("", true),
     UseIsNanNotNanComparison,
     UseIsNanNotSelfComparison,
@@ -344,6 +345,8 @@ case object FloatingPointNumericRange extends
   Warning("Avoid NumericRange with floating point numbers, as results may differ depending on which methods are used to materialize it (apply vs. foreach).")
 case class UseInitNotReverseTailReverse(varName: String) extends
   Warning(s"$varName.reverse.tail.reverse can be replaced by $varName.init.")
+case class UseTakeRightNotReverseTakeReverse(varName: String) extends
+  Warning(s"$varName.reverse.take(...).reverse can be replaced by $varName.takeRight(...).")
 case class UseLastNotReverseHead(varName: String, option: Boolean) extends
   Warning(s"""$varName.reverse.head${if (option) "Option" else ""} can be replaced by $varName.last${if (option) "Option" else ""}.""")
 case class UseFuncNotReverse(varName: String, func: String) extends

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1155,6 +1155,15 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
   }
 
   @Test
+  def UseTakeRightNotReverseTakeReverse(): Unit = {
+    implicit val msg = "reverse.take(...).reverse can be replaced by"
+    should("""List(1, 2, 3).reverse.take(2).reverse""")
+    should("""Array(1, 2, 3).reverse.take(0).reverse""")
+    should("""val a = Array("a", "b"); val n = 3; a.reverse.take(n).reverse""")
+    should("""val a = Vector("a", "b"); val n = 1; a.reverse.take(n).reverse""")
+  }
+
+  @Test
   def UseLastNotReverseHead(): Unit = {
     implicit var msg = "reverse.head can be replaced by"
     should("""List(1, 2, 3).reverse.head""")

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1167,6 +1167,21 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
   }
 
   @Test
+  def UseFuncNotReverse(): Unit = {
+    implicit var msg = "reverse.iterator can be replaced by"
+    should("""List(1, 2, 3).reverse.iterator""")
+    should("""Array(1, 2, 3).reverse.iterator""")
+    should("""val a = Array("a", "b"); a.reverse.iterator""")
+    should("""val a = Vector("a", "b"); a.reverse.iterator""")
+
+    msg = "reverse.map can be replaced by"
+    should("""List(1, 2, 3).reverse.map(_ + 1)""")
+    should("""Array(1, 2, 3).reverse.map(identity)""")
+    should("""val a = Array("a", "b"); a.reverse.map(_ * 2)""")
+    should("""val a = Vector("a", "b"); a.reverse.map(_.capitalize)""")
+  }
+
+  @Test
   def ReflexiveAssignment(): Unit = {
     implicit val msg = "Assigning a variable to itself?"
 

--- a/src/test/scala/WarningTest.scala
+++ b/src/test/scala/WarningTest.scala
@@ -110,6 +110,7 @@ class WarningTest extends JUnitMustMatchers {
       case UseFuncNotFold(_, _, _) => 1
       case UseMinOrMaxNotSort(_, _, _, _) => 1
       case UseInitNotReverseTailReverse(_) => 1
+      case UseTakeRightNotReverseTakeReverse(_) => 1
       case UseLastNotReverseHead(_, _) => 1
       case UseFuncNotReverse(_, _) => 1
       case FloatingPointNumericRange => 1

--- a/src/test/scala/WarningTest.scala
+++ b/src/test/scala/WarningTest.scala
@@ -111,6 +111,7 @@ class WarningTest extends JUnitMustMatchers {
       case UseMinOrMaxNotSort(_, _, _, _) => 1
       case UseInitNotReverseTailReverse(_) => 1
       case UseLastNotReverseHead(_, _) => 1
+      case UseFuncNotReverse(_, _) => 1
       case FloatingPointNumericRange => 1
       // ------------------------------------------------------------------------------------------------------
       // If you get a warning here, it's likely because you added a new warning type but forgot to add it here.


### PR DESCRIPTION
New checks with reverse (ideas from https://pavelfatin.com/scala-collections-tips-and-tricks/):

* reverse.map can be rewritten as reverseMap
* reverse.iterator can be rewritten as reverseIterator
* reverse.take(n).reverse can be rewritten as takeRight(n)