### PR TITLE
New checks: UseHeadNotApply, UseLastNotApply, UseHeadOptionNotIf, UseZipWithIndexNotZipIndices

### DIFF
--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -1788,6 +1788,11 @@ class LinterPlugin(val global: Global) extends Plugin {
 
             warn(tree, UseFuncNotReverse(identOrCol(col), func.toString))
 
+          case Apply(Select(col, Name("apply")), List(Literal(Constant(0))))
+            if col.tpe.widen.baseClasses.exists(c => c.tpe =:= SeqClass.tpe) =>
+
+            warn(tree, UseHeadNotApply(identOrCol(col)))
+
           /// Use partial function directly - temporary variable is unnecessary (idea by yzgw)
           case Apply(_, List(Function(List(ValDef(mods, x_1, typeTree: TypeTree, EmptyTree)), Match(x_1_, _))))
             if (((x_1 is "x$1") && (x_1_ is "x$1") && (mods.isSynthetic) && (mods.isParameter)) // _ match { ... }

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -1821,6 +1821,27 @@ class LinterPlugin(val global: Global) extends Plugin {
 
             warn(tree, UseHeadOptionNotIf(identOrCol(col)))
 
+          case If(Select(col, Name("nonEmpty")), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("last")))), scala_None)
+            if (col equalsStructure col1)
+            && (scala_Some is "scala.Some")
+            && (scala_None is "scala.None") =>
+
+            warn(tree, UseLastOptionNotIf(identOrCol(col)))
+
+          case If(Select(col, Name("isEmpty")), scala_None, Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("last")))))
+            if (col equalsStructure col1)
+            && (scala_Some is "scala.Some")
+            && (scala_None is "scala.None") =>
+
+            warn(tree, UseLastOptionNotIf(identOrCol(col)))
+
+          case If(Select(Select(col, Name("isEmpty")), nme.UNARY_!), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("last")))), scala_None)
+            if (col equalsStructure col1)
+            && (scala_Some is "scala.Some")
+            && (scala_None is "scala.None") =>
+
+            warn(tree, UseLastOptionNotIf(identOrCol(col)))
+
           /// Use partial function directly - temporary variable is unnecessary (idea by yzgw)
           case Apply(_, List(Function(List(ValDef(mods, x_1, typeTree: TypeTree, EmptyTree)), Match(x_1_, _))))
             if (((x_1 is "x$1") && (x_1_ is "x$1") && (mods.isSynthetic) && (mods.isParameter)) // _ match { ... }

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -1793,6 +1793,13 @@ class LinterPlugin(val global: Global) extends Plugin {
 
             warn(tree, UseHeadNotApply(identOrCol(col)))
 
+          case Apply(Select(col, Name("apply")), List(Apply(Select(Select(col1, size_length), Name("$minus")), List(Literal(Constant(1))))))
+            if col.tpe.widen.baseClasses.exists(c => c.tpe =:= SeqClass.tpe)
+            && size_length.isAny("size", "length")
+            && (col equalsStructure col1) =>
+
+            warn(tree, UseLastNotApply(identOrCol(col)))
+
           /// Use partial function directly - temporary variable is unnecessary (idea by yzgw)
           case Apply(_, List(Function(List(ValDef(mods, x_1, typeTree: TypeTree, EmptyTree)), Match(x_1_, _))))
             if (((x_1 is "x$1") && (x_1_ is "x$1") && (mods.isSynthetic) && (mods.isParameter)) // _ match { ... }

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -1800,6 +1800,27 @@ class LinterPlugin(val global: Global) extends Plugin {
 
             warn(tree, UseLastNotApply(identOrCol(col)))
 
+          case If(Select(col, Name("nonEmpty")), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("head")))), scala_None)
+            if (col equalsStructure col1)
+            && (scala_Some is "scala.Some")
+            && (scala_None is "scala.None") =>
+
+            warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+
+          case If(Select(col, Name("isEmpty")), scala_None, Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("head")))))
+            if (col equalsStructure col1)
+            && (scala_Some is "scala.Some")
+            && (scala_None is "scala.None") =>
+
+            warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+
+          case If(Select(Select(col, Name("isEmpty")), nme.UNARY_!), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("head")))), scala_None)
+            if (col equalsStructure col1)
+            && (scala_Some is "scala.Some")
+            && (scala_None is "scala.None") =>
+
+            warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+
           /// Use partial function directly - temporary variable is unnecessary (idea by yzgw)
           case Apply(_, List(Function(List(ValDef(mods, x_1, typeTree: TypeTree, EmptyTree)), Match(x_1_, _))))
             if (((x_1 is "x$1") && (x_1_ is "x$1") && (mods.isSynthetic) && (mods.isParameter)) // _ match { ... }

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -1842,6 +1842,19 @@ class LinterPlugin(val global: Global) extends Plugin {
 
             warn(tree, UseLastOptionNotIf(identOrCol(col)))
 
+          case Apply(TypeApply(Select(col, Name("zip")), _), List(Select(col1, Name("indices"))))
+            if (col equalsStructure col1)
+            && col.tpe.widen.baseClasses.exists(c => c.tpe =:= TraversableClass.tpe) =>
+
+            warn(tree, UseZipWithIndexNotZipIndices(identOrCol(col)))
+
+          case Apply(TypeApply(Select(Apply(xArrayOps1, List(col)), Name("zip")), _), List(Select(Apply(xArrayOps2, List(col1)), Name("indices"))))
+            if (col equalsStructure col1)
+            && (xArrayOps1.containsAny("ArrayOps", "augmentString"))
+            && (xArrayOps2.containsAny("ArrayOps", "augmentString")) =>
+
+            warn(tree, UseZipWithIndexNotZipIndices(identOrCol(col)))
+
           /// Use partial function directly - temporary variable is unnecessary (idea by yzgw)
           case Apply(_, List(Function(List(ValDef(mods, x_1, typeTree: TypeTree, EmptyTree)), Match(x_1_, _))))
             if (((x_1 is "x$1") && (x_1_ is "x$1") && (mods.isSynthetic) && (mods.isParameter)) // _ match { ... }

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -1789,12 +1789,12 @@ class LinterPlugin(val global: Global) extends Plugin {
             warn(tree, UseFuncNotReverse(identOrCol(col), func.toString))
 
           case Apply(Select(col, Name("apply")), List(Literal(Constant(0))))
-            if col.tpe.widen.baseClasses.exists(c => c.tpe =:= SeqClass.tpe) =>
+            if col.tpe.widen.baseClasses.exists(c => c.tpe =:= ListClass.tpe) =>
 
             warn(tree, UseHeadNotApply(identOrCol(col)))
 
           case Apply(Select(col, Name("apply")), List(Apply(Select(Select(col1, size_length), Name("$minus")), List(Literal(Constant(1))))))
-            if col.tpe.widen.baseClasses.exists(c => c.tpe =:= SeqClass.tpe)
+            if col.tpe.widen.baseClasses.exists(c => c.tpe =:= ListClass.tpe)
             && size_length.isAny("size", "length")
             && (col equalsStructure col1) =>
 

--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -1800,47 +1800,82 @@ class LinterPlugin(val global: Global) extends Plugin {
 
             warn(tree, UseLastNotApply(identOrCol(col)))
 
-          case If(Select(col, Name("nonEmpty")), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("head")))), scala_None)
+          // if (list.nonEmpty) Some(list.head) else None
+          case If(Select(col, Name("nonEmpty")), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, head_last))), scala_None)
             if (col equalsStructure col1)
+            && head_last.isAny("head", "last")
             && (scala_Some is "scala.Some")
             && (scala_None is "scala.None") =>
 
-            warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+            head_last match {
+              case Name("head") => warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+              case Name("last") => warn(tree, UseLastOptionNotIf(identOrCol(col)))
+            }
 
-          case If(Select(col, Name("isEmpty")), scala_None, Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("head")))))
+
+          // if (str.nonEmpty) Some(str.head) else None
+          case If(Select(Apply(xArrayOps1, List(col)), Name("nonEmpty")), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(Apply(xArrayOps2, List(col1)), head_last))), scala_None)
             if (col equalsStructure col1)
+            && head_last.isAny("head", "last")
+            && (xArrayOps1.containsAny("ArrayOps", "augmentString"))
+            && (xArrayOps2.containsAny("ArrayOps", "augmentString"))
             && (scala_Some is "scala.Some")
             && (scala_None is "scala.None") =>
 
-            warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+            head_last match {
+              case Name("head") => warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+              case Name("last") => warn(tree, UseLastOptionNotIf(identOrCol(col)))
+            }
 
-          case If(Select(Select(col, Name("isEmpty")), nme.UNARY_!), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("head")))), scala_None)
+          // if (list.isEmpty) None else Some(list.head)
+          case If(Select(col, Name("isEmpty")), scala_None, Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, head_last))))
             if (col equalsStructure col1)
+            && head_last.isAny("head", "last")
             && (scala_Some is "scala.Some")
             && (scala_None is "scala.None") =>
 
-            warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+            head_last match {
+              case Name("head") => warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+              case Name("last") => warn(tree, UseLastOptionNotIf(identOrCol(col)))
+            }
 
-          case If(Select(col, Name("nonEmpty")), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("last")))), scala_None)
+          // if (str.isEmpty) None else Some(s.head)
+          case If(Apply(Select(col, Name("isEmpty")), _), scala_None, Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(Apply(xArrayOps, List(col1)), head_last))))
             if (col equalsStructure col1)
+            && head_last.isAny("head", "last")
+            && (xArrayOps.containsAny("ArrayOps", "augmentString"))
             && (scala_Some is "scala.Some")
             && (scala_None is "scala.None") =>
 
-            warn(tree, UseLastOptionNotIf(identOrCol(col)))
+            head_last match {
+              case Name("head") => warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+              case Name("last") => warn(tree, UseLastOptionNotIf(identOrCol(col)))
+            }
 
-          case If(Select(col, Name("isEmpty")), scala_None, Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("last")))))
+          // if (!list.isEmpty) Some(list.head) else None
+          case If(Select(Select(col, Name("isEmpty")), nme.UNARY_!), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, head_last))), scala_None)
             if (col equalsStructure col1)
+            && head_last.isAny("head", "last")
             && (scala_Some is "scala.Some")
             && (scala_None is "scala.None") =>
 
-            warn(tree, UseLastOptionNotIf(identOrCol(col)))
+            head_last match {
+              case Name("head") => warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+              case Name("last") => warn(tree, UseLastOptionNotIf(identOrCol(col)))
+            }
 
-          case If(Select(Select(col, Name("isEmpty")), nme.UNARY_!), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(col1, Name("last")))), scala_None)
+          // if (!str.isEmpty) Some(str.head) else None
+          case If(Select(Apply(Select(col, Name("isEmpty")), _), nme.UNARY_!), Apply(TypeApply(Select(scala_Some, Name("apply")), _), List(Select(Apply(xArrayOps, List(col1)), head_last))), scala_None)
             if (col equalsStructure col1)
+            && head_last.isAny("head", "last")
+            && (xArrayOps.containsAny("ArrayOps", "augmentString"))
             && (scala_Some is "scala.Some")
             && (scala_None is "scala.None") =>
 
-            warn(tree, UseLastOptionNotIf(identOrCol(col)))
+            head_last match {
+              case Name("head") => warn(tree, UseHeadOptionNotIf(identOrCol(col)))
+              case Name("last") => warn(tree, UseLastOptionNotIf(identOrCol(col)))
+            }
 
           case Apply(TypeApply(Select(col, Name("zip")), _), List(Select(col1, Name("indices"))))
             if (col equalsStructure col1)

--- a/src/main/scala/Warning.scala
+++ b/src/main/scala/Warning.scala
@@ -114,6 +114,7 @@ object Warning {
     UseTakeRightNotReverseTakeReverse(""),
     UseLastNotApply(""),
     UseLastNotReverseHead("", true),
+    UseLastOptionNotIf(""),
     UseIsNanNotNanComparison,
     UseIsNanNotSelfComparison,
     UseOptionGetOrElse("", ""),
@@ -360,3 +361,5 @@ case class UseLastNotApply(varName: String) extends
   Warning(s"""$varName($varName.length - 1) can be replaced by $varName.last""")
 case class UseHeadOptionNotIf(varName: String) extends
   Warning(s"""if ($varName.nonEmpty) Some($varName.head) else None can be replaced by $varName.headOption""")
+case class UseLastOptionNotIf(varName: String) extends
+  Warning(s"""if ($varName.nonEmpty) Some($varName.last) else None can be replaced by $varName.lastOption""")

--- a/src/main/scala/Warning.scala
+++ b/src/main/scala/Warning.scala
@@ -109,6 +109,7 @@ object Warning {
     UseFuncNotFold("", "", ""),
     UseFuncNotReverse("", ""),
     UseHeadNotApply(""),
+    UseHeadOptionNotIf(""),
     UseInitNotReverseTailReverse(""),
     UseTakeRightNotReverseTakeReverse(""),
     UseLastNotApply(""),
@@ -357,3 +358,5 @@ case class UseHeadNotApply(varName: String) extends
   Warning(s"""$varName(0) can be replaced by $varName.head""")
 case class UseLastNotApply(varName: String) extends
   Warning(s"""$varName($varName.length - 1) can be replaced by $varName.last""")
+case class UseHeadOptionNotIf(varName: String) extends
+  Warning(s"""if ($varName.nonEmpty) Some($varName.head) else None can be replaced by $varName.headOption""")

--- a/src/main/scala/Warning.scala
+++ b/src/main/scala/Warning.scala
@@ -111,6 +111,7 @@ object Warning {
     UseHeadNotApply(""),
     UseInitNotReverseTailReverse(""),
     UseTakeRightNotReverseTakeReverse(""),
+    UseLastNotApply(""),
     UseLastNotReverseHead("", true),
     UseIsNanNotNanComparison,
     UseIsNanNotSelfComparison,
@@ -354,3 +355,5 @@ case class UseFuncNotReverse(varName: String, func: String) extends
   Warning(s"""$varName.reverse.$func can be replaced by $varName.reverse${func.capitalize}.""")
 case class UseHeadNotApply(varName: String) extends
   Warning(s"""$varName(0) can be replaced by $varName.head""")
+case class UseLastNotApply(varName: String) extends
+  Warning(s"""$varName($varName.length - 1) can be replaced by $varName.last""")

--- a/src/main/scala/Warning.scala
+++ b/src/main/scala/Warning.scala
@@ -121,6 +121,7 @@ object Warning {
     UseOptionOrNull("", ""),
     UseSignum,
     UseUntilNotToMinusOne,
+    UseZipWithIndexNotZipIndices(""),
     VariableAssignedUnusedValue(""),
     WrapNullWithOption,
     YodaConditions,
@@ -363,3 +364,5 @@ case class UseHeadOptionNotIf(varName: String) extends
   Warning(s"""if ($varName.nonEmpty) Some($varName.head) else None can be replaced by $varName.headOption""")
 case class UseLastOptionNotIf(varName: String) extends
   Warning(s"""if ($varName.nonEmpty) Some($varName.last) else None can be replaced by $varName.lastOption""")
+case class UseZipWithIndexNotZipIndices(varName: String) extends
+  Warning(s"""$varName.zip($varName.indices) can be replaced with $varName.zipWithIndex""")

--- a/src/main/scala/Warning.scala
+++ b/src/main/scala/Warning.scala
@@ -108,6 +108,7 @@ object Warning {
     UseFuncNotReduce("", "", ""),
     UseFuncNotFold("", "", ""),
     UseFuncNotReverse("", ""),
+    UseHeadNotApply(""),
     UseInitNotReverseTailReverse(""),
     UseTakeRightNotReverseTakeReverse(""),
     UseLastNotReverseHead("", true),
@@ -351,3 +352,5 @@ case class UseLastNotReverseHead(varName: String, option: Boolean) extends
   Warning(s"""$varName.reverse.head${if (option) "Option" else ""} can be replaced by $varName.last${if (option) "Option" else ""}.""")
 case class UseFuncNotReverse(varName: String, func: String) extends
   Warning(s"""$varName.reverse.$func can be replaced by $varName.reverse${func.capitalize}.""")
+case class UseHeadNotApply(varName: String) extends
+  Warning(s"""$varName(0) can be replaced by $varName.head""")

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1223,6 +1223,14 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
   }
 
   @Test
+  def UseHeadOptionNotIf(): Unit = {
+    implicit val msg = ".head) else None can be replaced by"
+    should("""def headOpt[A](l: List[A]) = if (l.nonEmpty) Some(l.head) else None""")
+    should("""if (!Vector("a").isEmpty) Some(Vector("a").head) else None""")
+    should("""if (Seq("a").isEmpty) None else Some(Seq("a").head)""")
+  }
+
+  @Test
   def ReflexiveAssignment(): Unit = {
     implicit val msg = "Assigning a variable to itself?"
 

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1212,14 +1212,20 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
   def UseHeadNotApply(): Unit = {
     implicit val msg = "(0) can be replaced by"
     should("""List(1, 2, 3)(0)""")
-    should("""val a = Vector("a", "b"); a(0)""")
+    noLint("""val seq = Seq("a", "b"); seq(0)""")
+    noLint("""val v = Vector("a", "b"); v(0)""")
+    noLint("""val a = Array(1, 2); a(0)""")
+    noLint("""val s = "abc; s(0)"""")
   }
 
   @Test
   def UseLastNotApply(): Unit = {
     implicit val msg = ".length - 1) can be replaced by"
     should("""val l = List(1, 2, 3); l(l.length - 1)""")
-    should("""val a = Vector("a", "b"); a.apply(a.size - 1)""")
+    noLint("""val seq = Seq("a", "b"); seq(seq.size - 1)""")
+    noLint("""val v = Vector("a", "b"); v(v.length - 1)""")
+    noLint("""val a = Array(4, 2); a(a.size - 1)""")
+    noLint("""val s = "xyz"; s(s.length - 1)""")
   }
 
   @Test

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1216,6 +1216,13 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
   }
 
   @Test
+  def UseLastNotApply(): Unit = {
+    implicit val msg = ".length - 1) can be replaced by"
+    should("""val l = List(1, 2, 3); l(l.length - 1)""")
+    should("""val a = Vector("a", "b"); a.apply(a.size - 1)""")
+  }
+
+  @Test
   def ReflexiveAssignment(): Unit = {
     implicit val msg = "Assigning a variable to itself?"
 
@@ -2375,14 +2382,6 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
       a(b-1)
     """)
 
-    noLint("""
-      val a = List(1,2,3)
-      a(a.size-1)
-    """)
-    noLint("""
-      val a = List(1,2,3)
-      a(a.length-1)
-    """)
     noLint("""
       val a = List(1,2,3)
       val b = 5

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1231,6 +1231,14 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
   }
 
   @Test
+  def UseLastOptionNotIf(): Unit = {
+    implicit val msg = ".last) else None can be replaced by"
+    should("""def lastOpt[A](l: List[A]) = if (l.nonEmpty) Some(l.last) else None""")
+    should("""if (!Vector("a").isEmpty) Some(Vector("a").last) else None""")
+    should("""if (Seq("a").isEmpty) None else Some(Seq("a").last)""")
+  }
+
+  @Test
   def ReflexiveAssignment(): Unit = {
     implicit val msg = "Assigning a variable to itself?"
 

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1228,12 +1228,12 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
     should("""def headOpt[A](l: List[A]) = if (l.nonEmpty) Some(l.head) else None""")
     should("""def headOpt[A](l: List[A]) = if (l.isEmpty) None else Some(l.head)""")
     should("""def headOpt[A](l: List[A]) = if (!l.isEmpty) Some(l.head) else None""")
-    should("""def headOpt[A](l: Array[A]) = if (l.nonEmpty) Some(l.head) else None""")
-    should("""def headOpt[A](l: Array[A]) = if (l.isEmpty) None else Some(l.head)""")
-    should("""def headOpt[A](l: Array[A]) = if (!l.isEmpty) Some(l.head) else None""")
-    should("""def headOpt[A](l: String) = if (l.nonEmpty) Some(l.head) else None""")
-    should("""def headOpt[A](l: String) = if (l.isEmpty) None else Some(l.head)""")
-    should("""def headOpt[A](l: String) = if (!l.isEmpty) Some(l.head) else None""")
+    should("""def headOpt[A](a: Array[A]) = if (a.nonEmpty) Some(a.head) else None""")
+    should("""def headOpt[A](a: Array[A]) = if (a.isEmpty) None else Some(a.head)""")
+    should("""def headOpt[A](a: Array[A]) = if (!a.isEmpty) Some(a.head) else None""")
+    should("""def headOpt[A](s: String) = if (s.nonEmpty) Some(s.head) else None""")
+    should("""def headOpt[A](s: String) = if (s.isEmpty) None else Some(s.head)""")
+    should("""def headOpt[A](s: String) = if (!s.isEmpty) Some(s.head) else None""")
   }
 
   @Test
@@ -1242,12 +1242,12 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
     should("""def lastOpt[A](l: List[A]) = if (l.nonEmpty) Some(l.last) else None""")
     should("""def lastOpt[A](l: List[A]) = if (l.isEmpty) None else Some(l.last)""")
     should("""def lastOpt[A](l: List[A]) = if (!l.isEmpty) Some(l.last) else None""")
-    should("""def lastOpt[A](l: Array[A]) = if (l.nonEmpty) Some(l.last) else None""")
-    should("""def lastOpt[A](l: Array[A]) = if (l.isEmpty) None else Some(l.last)""")
-    should("""def lastOpt[A](l: Array[A]) = if (!l.isEmpty) Some(l.last) else None""")
-    should("""def lastOpt[A](l: String) = if (l.nonEmpty) Some(l.last) else None""")
-    should("""def lastOpt[A](l: String) = if (l.isEmpty) None else Some(l.last)""")
-    should("""def lastOpt[A](l: String) = if (!l.isEmpty) Some(l.last) else None""")
+    should("""def lastOpt[A](a: Array[A]) = if (a.nonEmpty) Some(a.last) else None""")
+    should("""def lastOpt[A](a: Array[A]) = if (a.isEmpty) None else Some(a.last)""")
+    should("""def lastOpt[A](a: Array[A]) = if (!a.isEmpty) Some(a.last) else None""")
+    should("""def lastOpt[A](s: String) = if (s.nonEmpty) Some(s.last) else None""")
+    should("""def lastOpt[A](s: String) = if (s.isEmpty) None else Some(s.last)""")
+    should("""def lastOpt[A](s: String) = if (!s.isEmpty) Some(s.last) else None""")
   }
 
   @Test

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1171,10 +1171,10 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
   @Test
   def UseTakeRightNotReverseTakeReverse(): Unit = {
     implicit val msg = "reverse.take(...).reverse can be replaced by"
-    should("""List(1, 2, 3).reverse.take(2).reverse""")
+    should("""List(1, 2, 3).reverse.take(1 + 1).reverse""")
     should("""Array(1, 2, 3).reverse.take(0).reverse""")
     should("""val a = Array("a", "b"); val n = 3; a.reverse.take(n).reverse""")
-    should("""val a = Vector("a", "b"); val n = 1; a.reverse.take(n).reverse""")
+    should("""val a = Vector("a", "b"); val n = 1; a.reverse.take(2 - n).reverse""")
     should(""""abc".reverse.take(2).reverse""")
   }
 
@@ -1206,6 +1206,13 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
     should("""val a = Array("a", "b"); a.reverse.map(_ * 2)""")
     should("""val a = Vector("a", "b"); a.reverse.map(_.capitalize)""")
     should(""""abc".reverse.map(_ + 1)""")
+  }
+
+  @Test
+  def UseHeadNotApply(): Unit = {
+    implicit val msg = "(0) can be replaced by"
+    should("""List(1, 2, 3)(0)""")
+    should("""val a = Vector("a", "b"); a(0)""")
   }
 
   @Test
@@ -2330,10 +2337,6 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
       a(b.size-b.length-1)
     """)
 
-    noLint("""
-      val a = List(1,2,3)
-      a(0)
-    """)
     noLint("""
       val a = List(1,2,3)
       a(a.size-a.size)

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1239,6 +1239,14 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
   }
 
   @Test
+  def UseZipWithIndexNotZipIndices(): Unit = {
+    implicit val msg = ".indices) can be replaced with"
+    should("""val l = List(1, 2, 3); l.zip(l.indices)""")
+    should("""val a = Array('a', 'b', 'c'); a.zip(a.indices)""")
+    should("""val s = "abc"; s.zip(s.indices)""")
+  }
+
+  @Test
   def ReflexiveAssignment(): Unit = {
     implicit val msg = "Assigning a variable to itself?"
 

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1226,16 +1226,28 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
   def UseHeadOptionNotIf(): Unit = {
     implicit val msg = ".head) else None can be replaced by"
     should("""def headOpt[A](l: List[A]) = if (l.nonEmpty) Some(l.head) else None""")
-    should("""if (!Vector("a").isEmpty) Some(Vector("a").head) else None""")
-    should("""if (Seq("a").isEmpty) None else Some(Seq("a").head)""")
+    should("""def headOpt[A](l: List[A]) = if (l.isEmpty) None else Some(l.head)""")
+    should("""def headOpt[A](l: List[A]) = if (!l.isEmpty) Some(l.head) else None""")
+    should("""def headOpt[A](l: Array[A]) = if (l.nonEmpty) Some(l.head) else None""")
+    should("""def headOpt[A](l: Array[A]) = if (l.isEmpty) None else Some(l.head)""")
+    should("""def headOpt[A](l: Array[A]) = if (!l.isEmpty) Some(l.head) else None""")
+    should("""def headOpt[A](l: String) = if (l.nonEmpty) Some(l.head) else None""")
+    should("""def headOpt[A](l: String) = if (l.isEmpty) None else Some(l.head)""")
+    should("""def headOpt[A](l: String) = if (!l.isEmpty) Some(l.head) else None""")
   }
 
   @Test
   def UseLastOptionNotIf(): Unit = {
     implicit val msg = ".last) else None can be replaced by"
     should("""def lastOpt[A](l: List[A]) = if (l.nonEmpty) Some(l.last) else None""")
-    should("""if (!Vector("a").isEmpty) Some(Vector("a").last) else None""")
-    should("""if (Seq("a").isEmpty) None else Some(Seq("a").last)""")
+    should("""def lastOpt[A](l: List[A]) = if (l.isEmpty) None else Some(l.last)""")
+    should("""def lastOpt[A](l: List[A]) = if (!l.isEmpty) Some(l.last) else None""")
+    should("""def lastOpt[A](l: Array[A]) = if (l.nonEmpty) Some(l.last) else None""")
+    should("""def lastOpt[A](l: Array[A]) = if (l.isEmpty) None else Some(l.last)""")
+    should("""def lastOpt[A](l: Array[A]) = if (!l.isEmpty) Some(l.last) else None""")
+    should("""def lastOpt[A](l: String) = if (l.nonEmpty) Some(l.last) else None""")
+    should("""def lastOpt[A](l: String) = if (l.isEmpty) None else Some(l.last)""")
+    should("""def lastOpt[A](l: String) = if (!l.isEmpty) Some(l.last) else None""")
   }
 
   @Test

--- a/src/test/scala/WarningTest.scala
+++ b/src/test/scala/WarningTest.scala
@@ -116,6 +116,7 @@ class WarningTest extends JUnitMustMatchers {
       case UseHeadNotApply(_) => 1
       case UseLastNotApply(_) => 1
       case UseHeadOptionNotIf(_) => 1
+      case UseLastOptionNotIf(_) => 1
       case FloatingPointNumericRange => 1
       // ------------------------------------------------------------------------------------------------------
       // If you get a warning here, it's likely because you added a new warning type but forgot to add it here.

--- a/src/test/scala/WarningTest.scala
+++ b/src/test/scala/WarningTest.scala
@@ -113,6 +113,7 @@ class WarningTest extends JUnitMustMatchers {
       case UseTakeRightNotReverseTakeReverse(_) => 1
       case UseLastNotReverseHead(_, _) => 1
       case UseFuncNotReverse(_, _) => 1
+      case UseHeadNotApply(_) => 1
       case FloatingPointNumericRange => 1
       // ------------------------------------------------------------------------------------------------------
       // If you get a warning here, it's likely because you added a new warning type but forgot to add it here.

--- a/src/test/scala/WarningTest.scala
+++ b/src/test/scala/WarningTest.scala
@@ -117,6 +117,7 @@ class WarningTest extends JUnitMustMatchers {
       case UseLastNotApply(_) => 1
       case UseHeadOptionNotIf(_) => 1
       case UseLastOptionNotIf(_) => 1
+      case UseZipWithIndexNotZipIndices(_) => 1
       case FloatingPointNumericRange => 1
       // ------------------------------------------------------------------------------------------------------
       // If you get a warning here, it's likely because you added a new warning type but forgot to add it here.

--- a/src/test/scala/WarningTest.scala
+++ b/src/test/scala/WarningTest.scala
@@ -114,6 +114,7 @@ class WarningTest extends JUnitMustMatchers {
       case UseLastNotReverseHead(_, _) => 1
       case UseFuncNotReverse(_, _) => 1
       case UseHeadNotApply(_) => 1
+      case UseLastNotApply(_) => 1
       case FloatingPointNumericRange => 1
       // ------------------------------------------------------------------------------------------------------
       // If you get a warning here, it's likely because you added a new warning type but forgot to add it here.

--- a/src/test/scala/WarningTest.scala
+++ b/src/test/scala/WarningTest.scala
@@ -115,6 +115,7 @@ class WarningTest extends JUnitMustMatchers {
       case UseFuncNotReverse(_, _) => 1
       case UseHeadNotApply(_) => 1
       case UseLastNotApply(_) => 1
+      case UseHeadOptionNotIf(_) => 1
       case FloatingPointNumericRange => 1
       // ------------------------------------------------------------------------------------------------------
       // If you get a warning here, it's likely because you added a new warning type but forgot to add it here.


### PR DESCRIPTION
New checks:

* `l(0)` can be replaced with `a.head` for collections. It might be controversial for arrays as index access is typical so I have not added it for these
* `l(l.length -1)` can be replaced with `l.last`
* `if (l.nonEmpty) Some(l.head) else None` can be replaced with `l.headOption`. I've added a couple of variants of this. I haven't added `if (!l.nonEmpty)` because it seems to me that double negation should be handled by a separate check.
* similarly, `if (l.nonEmpty) Some(l.last) else None` can be replaced with `l.lastOption`
* `l.zip(l.indices)` can be replaced with `l.zipWithIndex`

This pull request also interacts with a couple of other features so had to remove a couple noList checks.