### PR TITLE
New checks for pattern matching on Option

### DIFF
--- a/src/main/scala/Warning.scala
+++ b/src/main/scala/Warning.scala
@@ -131,7 +131,17 @@ object Warning {
     UnthrownException,
     SuspiciousMatches,
     IfDoWhile,
-    FloatingPointNumericRange
+    FloatingPointNumericRange,
+    UseGetOrElseNotPatMatch(""),
+    UseOrElseNotPatMatch(""),
+    UseOptionFlatMapNotPatMatch(""),
+    UseOptionMapNotPatMatch(""),
+    UseOptionFlattenNotPatMatch,
+    UseOptionForeachNotPatMatch(""),
+    UseOptionIsDefinedNotPatMatch,
+    UseOptionIsEmptyNotPatMatch,
+    UseOptionForallNotPatMatch(""),
+    UseOptionExistsNotPatMatch("")
   )
 
   final val AllNames = All.map(_.name)
@@ -367,3 +377,24 @@ case class UseLastOptionNotIf(varName: String) extends
   Warning(s"""if ($varName.nonEmpty) Some($varName.last) else None can be replaced by $varName.lastOption""")
 case class UseZipWithIndexNotZipIndices(varName: String) extends
   Warning(s"""$varName.zip($varName.indices) can be replaced with $varName.zipWithIndex""")
+case class UseGetOrElseNotPatMatch(expr: String) extends
+  Warning(s"""... match { Some(x) => x; None => $expr} can be replaced with .getOrElse($expr)""")
+
+case class UseOrElseNotPatMatch(expr: String) extends
+  Warning(s"""... match { Some(x) => Some(x); None => $expr} can be replaced with .orElse($expr)""")
+case class UseOptionFlatMapNotPatMatch(expr: String) extends
+  Warning(s"""... match { Some(x) => $expr; None => None} can be replaced with .flatMap($expr)""")
+case class UseOptionMapNotPatMatch(expr: String) extends
+  Warning(s"""... match { Some(x) => Some($expr); None => None} can be replaced with .map($expr)""")
+case object UseOptionFlattenNotPatMatch extends
+  Warning(s"""... match { Some(x) => x; None => None} can be replaced with .flatten""")
+case class UseOptionForeachNotPatMatch(expr: String) extends
+  Warning(s"""... match { Some(x) => $expr; None => {} } can be replaced with .foreach($expr)""")
+case object UseOptionIsDefinedNotPatMatch extends
+  Warning(s"""... match { Some(x) => true; None => false} can be replaced with .isDefined""")
+case object UseOptionIsEmptyNotPatMatch extends
+  Warning(s"""... match { Some(x) => false; None => true} can be replaced with .isEmpty""")
+case class UseOptionForallNotPatMatch(expr: String) extends
+  Warning(s"""... match { Some(x) => true; None => $expr} can be replaced with .forall($expr)""")
+case class UseOptionExistsNotPatMatch(expr: String) extends
+  Warning(s"""... match { Some(x) => false; None => $expr} can be replaced with .exists($expr)""")

--- a/src/test/scala/LinterPluginTest.scala
+++ b/src/test/scala/LinterPluginTest.scala
@@ -1761,8 +1761,6 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
     should("""List(Some(1), None) map { item => item match { case Some(x) => x; case None => 10 }}""")
     should("""List(1,2,3) map { a => a match { case _ => 5 }}""")
     noLint("""List(1,2,3) map { a: AnyVal => a match { case _ => 5 }}""")
-    noLint("""List(Some(1), None) map { case Some(x) => x; case None => 10 }""")
-    noLint("""for(a <- List(Some(1), None)) a match { case Some(x) => x; case None => 10 }""")
   }
 
   @Test // see http://scalapuzzlers.com/#pzzlr-001
@@ -1963,6 +1961,86 @@ final class LinterPluginTest extends JUnitMustMatchers with StandardMatchResults
         case Some(x) => x
         case _ => null
       }""")
+  }
+
+  @Test
+  def UseGetOrElseNotPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .getOrElse"
+
+    should("""val o = Option(3); o match { case Some(x) => x; case None => 123}""")
+    should("""Option("hey") match {case None => ""; case Some(x) => x }""")
+  }
+
+  @Test
+  def UseOrElseNotPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .orElse"
+
+    should("""val o = Option(3); o match { case Some(x) => Some(x); case None => 123}""")
+    should("""Option("hey") match {case None => ""; case Some(x) => Some(x) }""")
+  }
+
+  @Test
+  def UseOptionFlatMapNotPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .flatMap"
+
+    should("""val o = Option(3); o match { case Some(x) => 123; case None => None}""")
+    should("""Option("hey") match {case None => None; case Some(x) => 123 }""")
+  }
+
+  @Test
+  def UseOptionMapPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .map"
+
+    should("""val o = Option(3); o match { case Some(x) => Some(123); case None => None}""")
+    should("""Option("hey") match {case None => None; case Some(x) => Some(123) }""")
+  }
+
+  @Test
+  def UseOptionFlattenNotPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .flatten"
+
+    should("""val o = Option(3); o match { case Some(x) => x; case None => None}""")
+    should("""Option("hey") match {case None => None; case Some(x) => x }""")
+  }
+
+  @Test
+  def UseOptionForeachNotPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .foreach"
+
+    should("""val o = Option(3); o match { case Some(x) => 123; case None => }""")
+    should("""Option("hey") match {case None => {}; case Some(x) => 123 }""")
+  }
+
+  @Test
+  def UseOptionIsDefinedNotPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .isDefined"
+
+    should("""val o = Option(3); o match { case Some(x) => true; case None => false }""")
+    should("""Option("hey") match {case None => false; case Some(x) => true }""")
+  }
+
+  @Test
+  def UseOptionIsEmptyNotPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .isEmpty"
+
+    should("""val o = Option(3); o match { case Some(x) => false; case None => true }""")
+    should("""Option("hey") match {case None => true; case Some(x) => false }""")
+  }
+
+  @Test
+  def UseOptionExistsNotPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .exists"
+
+    should("""val o = Option(3); o match { case Some(x) => x % 2 == 0; case None => false }""")
+    should("""Option("hey") match {case None => false; case Some(x) => x.isEmpty }""")
+  }
+
+  @Test
+  def UseOptionForallNotPatMatch(): Unit = {
+    implicit val msg = "can be replaced with .forall"
+
+    should("""val o = Option(3); o match { case Some(x) => x % 2 == 0; case None => true }""")
+    should("""Option("hey") match {case None => true; case Some(x) => x.isEmpty }""")
   }
 
   @Test

--- a/src/test/scala/WarningTest.scala
+++ b/src/test/scala/WarningTest.scala
@@ -118,6 +118,16 @@ class WarningTest extends JUnitMustMatchers {
       case UseLastOptionNotIf(_) => 1
       case UseZipWithIndexNotZipIndices(_) => 1
       case FloatingPointNumericRange => 1
+      case UseGetOrElseNotPatMatch(_) => 1
+      case UseOrElseNotPatMatch(_) => 1
+      case UseOptionFlatMapNotPatMatch(_) => 1
+      case UseOptionMapNotPatMatch(_) => 1
+      case UseOptionFlattenNotPatMatch => 1
+      case UseOptionForeachNotPatMatch(_) => 1
+      case UseOptionIsDefinedNotPatMatch => 1
+      case UseOptionIsEmptyNotPatMatch => 1
+      case UseOptionForallNotPatMatch(_) => 1
+      case UseOptionExistsNotPatMatch(_) => 1
       // ------------------------------------------------------------------------------------------------------
       // If you get a warning here, it's likely because you added a new warning type but forgot to add it here.
       // The real point is that you need to add the new Warning to Warning.All.


### PR DESCRIPTION
New checks for replacing pattern matching on Option with:
* getOrElse
* orElse
* flatMap
* map
* flatten
* foreach
* isDefined
* isEmpty
* forall
* exists

As per http://blog.tmorris.net/posts/scalaoption-cheat-sheet/ and https://pavelfatin.com/scala-collections-tips-and-tricks/#options-processing