### PR TITLE
remove oraclejdk7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
 
 jdk:
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
 
 sudo: false


### PR DESCRIPTION
travis-ci no longer support oraclejdk7
https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879